### PR TITLE
Disable auth timeout minutes

### DIFF
--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -73,6 +73,7 @@ rserver \
   --auth-none 0 \
   --auth-pam-helper-path "${RSTUDIO_AUTH}" \
   --auth-encrypt-password 0 \
+  --auth-timeout-minutes 0 \
   --rsession-path "${RSESSION_WRAPPER_FILE}" \
   --server-data-dir "${TMPDIR}/rserver-${SLURM_JOB_ID}" \
   --secure-cookie-key-file "${TMPDIR}/rserver-${SLURM_JOB_ID}/rstudio-server/secure-cookie-key" \


### PR DESCRIPTION
Setting auth timeout minutes to 0 will enable stay signed in days,
  which is default to 30 days

  --auth-timeout-minutes arg (=60)      The number of minutes a user will stay
                                        logged in while idle before required to
                                        sign in again. Set this to 0 (disabled)
                                        to enable legacy timeout
                                        auth-stay-signed-in-days.
  --auth-stay-signed-in-days arg (=30)  The number of days to keep a user
                                        signed in when using the "Stay Signed
                                        In" option. Will only take affect when
                                        auth-timeout-minutes is 0 (disabled).